### PR TITLE
Add currency conversion API route and test fetch page

### DIFF
--- a/currency-converter/src/app/api/convert/route.ts
+++ b/currency-converter/src/app/api/convert/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  const apiKey = process.env.CURRENCY_API_KEY;
+
+  const res = await fetch(`https://api.currencyapi.com/v3/latest?apikey=${apiKey}&base_currency=USD`);
+  const data = await res.json();
+
+  return NextResponse.json(data);
+}

--- a/currency-converter/src/app/test-fetch/page.tsx
+++ b/currency-converter/src/app/test-fetch/page.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useFetch } from "@/hooks/useFetch";
+
+export default function TestFetchPage() {
+  const { data, loading, error } = useFetch<CurrencyAPIResponse>("/api/convert");
+
+  if (loading) return <p>Loading...</p>;
+  if (error) return <p>Error: {error}</p>;
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold mb-4">Exchange Rates (Base USD)</h1>
+      <ul className="list-disc list-inside">
+        {Object.entries(data?.data || {}).map(([currency, info]) => (
+          <li key={currency}>
+            {currency}: {info.value.toFixed(2)}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+type CurrencyAPIResponse = {
+  data: {
+    [currencyCode: string]: {
+      code: string;
+      value: number;
+    };
+  };
+};


### PR DESCRIPTION
This pull request introduces a new API endpoint for currency conversion and a corresponding client-side page to display the fetched exchange rates( temporarily ). The most important changes include the creation of the `GET` endpoint and the implementation of a client-side page to test the fetch functionality.

### API Endpoint Creation:
* [`currency-converter/src/app/api/convert/route.ts`](diffhunk://#diff-4010067d19263c71579338337cf2130d119f582945f57d0f4a90e26e0bf4a250R1-R10): Added a `GET` endpoint that fetches the latest currency exchange rates from an external API using an API key stored in environment variables. The response is returned in JSON format.

### Client-Side Page Implementation:
* [`currency-converter/src/app/test-fetch/page.tsx`](diffhunk://#diff-19771b5668cc3da53e9a7748d81fc61f515a52c40982104e029481b59d65e2e5R1-R32): Implemented a client-side page that uses a custom `useFetch` hook to fetch data from the newly created `GET` endpoint. The page displays the exchange rates in a list format, handling loading and error states appropriately.