### PR TITLE
[REFACTOR] Simplify error handling in useLocalStorage hook

### DIFF
--- a/currency-converter/src/hooks/useLocalStorage.tsx
+++ b/currency-converter/src/hooks/useLocalStorage.tsx
@@ -5,7 +5,7 @@ export function useLocalStorage<T>(key: string, initialValue: T) {
     try {
       const item = localStorage.getItem(key);
       return item ? JSON.parse(item) : initialValue;
-    } catch (err) {
+    } catch {
       return initialValue;
     }
   });


### PR DESCRIPTION
This pull request includes a small change to the `currency-converter/src/hooks/useLocalStorage.tsx` file. The change simplifies the error handling in the `useLocalStorage` hook by removing the unused `err` parameter from the `catch` block.

* [`currency-converter/src/hooks/useLocalStorage.tsx`](diffhunk://#diff-5b4d4082a2431248f86af2a213d2716fbfba4ff9611c9b2ea69eeca6a45adac2L8-R8): Removed the `err` parameter from the `catch` block in the `useLocalStorage` hook.